### PR TITLE
Fix hostname validation regex to support localhost and IP addresses

### DIFF
--- a/qml/AddServerPage.qml
+++ b/qml/AddServerPage.qml
@@ -51,7 +51,7 @@ Page {
             width: parent.width
             title: i18n.tr("Server URL")
             placeholder: i18n.tr("https://example.com/caldav")
-            validationRegex: "^https?://[\\w\\-]+(\\.[\\w\\-]+)+[/#?]?.*$"
+            validationRegex: "^https?://([\\w\\-]+(\\.[\\w\\-]+)*|\\d+\\.\\d+\\.\\d+\\.\\d+|\\[[0-9a-fA-F:]+\\])(:[0-9]+)?[/#?]?.*$"
             required: true
         }
 


### PR DESCRIPTION
The previous regex required at least one dot in the hostname, which prevented users from using localhost, IP addresses, or single-name hostnames.

Updated regex now supports:
- Domain names (example.com, subdomain.example.com)
- localhost and single-name hostnames
- IPv4 addresses (192.168.1.1)
- IPv6 addresses ([::1], [2001:db8::1])
- Optional port numbers (:8080)
- Paths and query parameters

Fixes the first issue in the repository.